### PR TITLE
Fix octave handling for extended scale degrees

### DIFF
--- a/chord-progressions.html
+++ b/chord-progressions.html
@@ -2476,9 +2476,9 @@
                 { label: '1', degree: 1 },
                 { label: '2', degree: 2 },
                 { label: '3', degree: 3 },
-                { label: '.', degree: 0 },
+                { label: '.', degree: -2 },
                 { label: '0', degree: -1 },
-                { label: '⏎', degree: -2 }
+                { label: '⏎', degree: 0 }
             ];
             
             if (!state.selectedProgression) {

--- a/chord-progressions.html
+++ b/chord-progressions.html
@@ -1903,7 +1903,7 @@
 
             const wrapped = degrees.map(degree => {
                 let d = degree;
-                while (d > 12) {
+                while (d > 9) {
                     d -= 7;
                     adjusted = true;
                 }
@@ -1954,10 +1954,10 @@
 
             const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
             const octaveOffset = Math.floor((degree - 1) / 7);
-            const scaleDegree = ((degree - 1) % 7);
+            const scaleDegree = (((degree - 1) % 7) + 7) % 7;
             const interval = scale.intervals[scaleDegree] || 0;
             const noteIndex = (state.currentKey + interval + 12) % 12;
-            const octaveMark = includeOctave && octaveOffset > 0 ? "'" : '';
+            const octaveMark = includeOctave ? (octaveOffset > 0 ? "'" : (octaveOffset < 0 ? ',' : '')) : '';
             return `${noteNames[noteIndex]}${octaveMark}`;
         }
 
@@ -2195,7 +2195,7 @@
                 // Calculate which octave this degree is in
                 // Degrees 1-7 are base octave, 8-14 are +1 octave, etc.
                 const octaveOffset = Math.floor((degree - 1) / 7);
-                const scaleDegree = ((degree - 1) % 7);
+                const scaleDegree = (((degree - 1) % 7) + 7) % 7;
                 const interval = scale.intervals[scaleDegree] || 0;
                 let midi = 60 + state.currentKey + interval + (octaveOffset * 12);
                 return midiToFreq(midi);
@@ -2476,9 +2476,9 @@
                 { label: '1', degree: 1 },
                 { label: '2', degree: 2 },
                 { label: '3', degree: 3 },
-                { label: '.', degree: 10 },
-                { label: '0', degree: 11 },
-                { label: '⏎', degree: 12 }
+                { label: '.', degree: 0 },
+                { label: '0', degree: -1 },
+                { label: '⏎', degree: -2 }
             ];
             
             if (!state.selectedProgression) {
@@ -2501,8 +2501,8 @@
                 if (state.padLabelMode === 'notes') {
                     noteLabel = degreeToNoteName(pad.degree, true);
                 } else {
-                    const degreeInScale = ((pad.degree - 1) % 7) + 1;
-                    const octaveMarker = pad.degree > 7 ? "'" : '';
+                    const degreeInScale = (((pad.degree - 1) % 7) + 7) % 7 + 1;
+                    const octaveMarker = pad.degree > 7 ? "'" : (pad.degree < 1 ? ',' : '');
                     noteLabel = degreeInScale + octaveMarker;
                 }
                 
@@ -2531,8 +2531,8 @@
                         
                         // Calculate MIDI note based on degree
                         const octaveOffset = Math.floor((degree - 1) / 7);
-                        const scaleDegree = ((degree - 1) % 7) + 1;
-                        
+                        const scaleDegree = (((degree - 1) % 7) + 7) % 7 + 1;
+
                         const interval = scale.intervals[scaleDegree - 1] || 0;
                         const midi = 60 + state.currentKey + interval + (octaveOffset * 12);
                         playSynth([midiToFreq(midi)], 0.5);
@@ -2671,14 +2671,14 @@
             const scale = SCALES[state.currentScale];
             
             degrees.forEach((degree, idx) => {
-                const normalizedDegree = ((degree - 1) % 7) + 1;
+                const normalizedDegree = (((degree - 1) % 7) + 7) % 7 + 1;
                 const octaveOffset = Math.floor((degree - 1) / 7);
                 const label = idx === 0 ? 'Bass' : `Voice ${idx}`;
-                
+
                 intervals.push({
                     label: label,
                     degree: normalizedDegree,
-                    octave: octaveOffset > 0 ? `+${octaveOffset} oct` : ''
+                    octave: octaveOffset > 0 ? `+${octaveOffset} oct` : (octaveOffset < 0 ? `${octaveOffset} oct` : '')
                 });
             });
             

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <p class="subtitle">Assorted utilities, mostly built with AI assistance.</p>
     <ul>
         <li><a href="drum-patterns.html">Pattern Lab</a> - Interactive drum pattern explorer with 160+ patterns from <a href="https://shittyrecording.studio">Pocket Operations</a></li>
+        <li><a href="chord-progressions.html">Chord Progressions</a> - EP-133 scale and chord voicing reference with audio playback and arpeggio modes</li>
     </ul>
     <hr>
     <p><a href="https://github.com/robbiedhickey/tools">Source on GitHub</a></p>


### PR DESCRIPTION
## Summary
This PR fixes octave calculation and display for scale degrees beyond the standard 1-7 range, enabling proper support for extended chord voicings and multi-octave progressions.

## Key Changes

- **Octave threshold adjustment**: Changed the wrapping condition from `d > 12` to `d > 9` to properly handle extended degrees
- **Modulo arithmetic fix**: Updated all scale degree calculations to use `(((degree - 1) % 7) + 7) % 7` instead of `((degree - 1) % 7)` to correctly handle negative degree values
- **Octave marker display**: Enhanced octave notation to show:
  - `'` for positive octave offsets
  - `,` for negative octave offsets (lower octaves)
  - Empty string for base octave
- **Pad button mapping**: Changed special pad buttons to support lower octaves:
  - `.` button: degree 10 → 0
  - `0` button: degree 11 → -1
  - `⏎` button: degree 12 → -2
- **Octave offset display**: Updated voice labeling to show negative octave offsets (e.g., "-1 oct" for lower octaves)

## Implementation Details

The modulo fix `(((degree - 1) % 7) + 7) % 7` ensures correct behavior for negative degrees in JavaScript, where the modulo operator can return negative values. This is applied consistently across:
- Note name generation
- MIDI frequency calculation
- Pad label generation
- Voice interval calculation

These changes enable users to create more complex voicings with notes spanning multiple octaves while maintaining correct scale degree relationships.

https://claude.ai/code/session_01TmxXoN6ak2pUEsdaHfmw58