### PR TITLE
[codex] fix albums me tab mobile overflow

### DIFF
--- a/1001-albums/index.html
+++ b/1001-albums/index.html
@@ -161,6 +161,7 @@
   /* bottom tab bar — hidden on desktop, shown on mobile */
   .bottom-nav {
     display: none; position: fixed; bottom: 0; left: 0; right: 0; z-index: 20;
+    width: 100%; max-width: 100vw; overflow: hidden;
     background: rgba(246, 245, 243, 0.88);
     -webkit-backdrop-filter: saturate(180%) blur(20px);
     backdrop-filter: saturate(180%) blur(20px);
@@ -172,7 +173,7 @@
     flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
     gap: 2px; padding: 10px 4px 8px; border: 0; background: none; cursor: pointer;
     color: var(--text-dim); text-decoration: none; font-family: inherit;
-    user-select: none; touch-action: manipulation; -webkit-touch-callout: none; position: relative;
+    min-width: 0; user-select: none; touch-action: manipulation; -webkit-touch-callout: none; position: relative;
   }
   .bottom-nav-item:hover { text-decoration: none; color: var(--text); }
   .bottom-nav-item { transition: transform 0.08s, opacity 0.08s; }
@@ -220,14 +221,14 @@
   .card h2 { margin: 0 0 12px; font-size: 16px; }
   .card h3 { margin: 0 0 8px; font-size: 14px; color: var(--text-dim); }
   .grid { display: grid; gap: 16px; }
-  .grid.cols-2 { grid-template-columns: 1fr 1fr; }
-  .grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+  .grid.cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .grid.cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   @media (max-width: 700px) { .grid.cols-2 { grid-template-columns: 1fr; } }
   @media (max-width: 700px) { .grid.cols-3 { gap: 8px; } }
 
   .stat { text-align: center; }
   .stat .num { font-size: 26px; font-weight: 700; }
-  .stat .label { font-size: 12px; color: var(--text-dim); }
+  .stat .label { font-size: 12px; color: var(--text-dim); overflow-wrap: anywhere; }
 
   .banner {
     border-radius: var(--radius); padding: 14px 16px; margin-bottom: 16px;
@@ -284,7 +285,7 @@
   .album-panel-tab {
     border: 0; border-bottom: 2px solid transparent; background: transparent;
     cursor: pointer; padding: 7px 10px; color: var(--text-dim); font-size: 13px;
-    user-select: none; touch-action: manipulation;
+    min-width: 0; user-select: none; touch-action: manipulation;
   }
   .album-panel-tab:active { opacity: 0.6; }
   .album-panel-tab.active { color: var(--accent); border-color: var(--accent); font-weight: 700; }
@@ -347,8 +348,9 @@
     display: inline-flex; align-items: center; gap: 6px;
     border: 1px solid var(--border); border-radius: 999px; padding: 4px 10px;
     background: var(--bg); font-size: 12px; cursor: pointer; font-family: inherit;
+    max-width: 100%; min-width: 0;
   }
-  .style-chip-name { color: var(--text); }
+  .style-chip-name { color: var(--text); min-width: 0; overflow: hidden; text-overflow: ellipsis; }
   .style-chip-rating { color: var(--accent); font-weight: 700; }
   .style-chip-rating.tier-green { color: var(--good); }
   .style-chip-rating.tier-perfect { color: var(--good); font-weight: 900 !important; }
@@ -488,6 +490,7 @@
     flex: 1; border-right: 1px solid var(--border); border-bottom: 0; border-radius: 0;
     text-transform: uppercase; letter-spacing: 0.03em; font-size: 11px;
     padding: 8px 6px; counter-increment: te-tab;
+    min-width: 0;
   }
   .te-panel .album-panel-tab:last-child { border-right: 0; }
   .te-panel .album-panel-tab::before { content: counter(te-tab, decimal-leading-zero) " "; opacity: 0.5; }
@@ -503,6 +506,16 @@
   }
   .te-panel .label-caption {
     font-size: 10px;
+  }
+  @media (max-width: 380px) {
+    .card { padding: 16px; }
+    .stat .num { font-size: 24px; }
+    .stat .label { font-size: 10px; line-height: 1.25; }
+    .te-panel .album-panel-tab {
+      font-size: 10px;
+      padding: 8px 4px;
+    }
+    .te-panel .album-panel-tab::before { display: none; }
   }
 
   /* Reviews tab (GlobalReviewsPreview) and Activity feed (ActivityView) */


### PR DESCRIPTION
## What changed
- Prevented the 1001 Albums Me tab stats grid, chips, and tab controls from forcing overflow at mobile widths.
- Added defensive sizing to the mobile bottom nav so it stays constrained to the viewport and all four items can shrink cleanly.

## Why
The PWA/mobile updates exposed a narrow-width layout issue where Me tab controls could exceed their container or appear clipped when testing mobile-like widths on desktop.

## Validation
- Ran `git diff --cached --check` before commit.
- Verified the Me route locally in headless Chrome at 320px, 390px, and 620px: bottom nav displayed with all four labels.
- Verified 621px switches back to the desktop nav behavior.
- Verified document width matched viewport width with no detected overflow offenders at tested mobile widths.
